### PR TITLE
fix: avoid interactive prompts during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
 FROM ubuntu:22.04
 
+# Avoid interactive prompts and set a default timezone
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
 # Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
     build-essential \
     g++ \
     make \
     perl \
     python3 \
     r-base \
+    tzdata \
     zlib1g-dev \
     libbz2-dev \
     liblzma-dev \
     libncurses5-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -fs /usr/share/zoneinfo/$TZ /etc/localtime \
+    && dpkg-reconfigure -f noninteractive tzdata
 
 # Set working directory
 WORKDIR /opt/rsem


### PR DESCRIPTION
## Summary
- prevent interactive prompts by setting DEBIAN_FRONTEND=noninteractive and default timezone
- add apt-utils and tzdata and configure timezone during build

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `docker build -t rsem-test .` *(fails: Cannot connect to the Docker daemon)*
- `dockerd` *(fails: failed to mount overlay: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b4d7b1008331bda8078d61207718