### PR TITLE
Add Bowtie and HTSlib tools to build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libbz2-dev \
     liblzma-dev \
     libncurses5-dev \
+    bowtie \
+    bowtie2 \
+    samtools \
+    tabix \
     && rm -rf /var/lib/apt/lists/* \
     && ln -fs /usr/share/zoneinfo/$TZ /etc/localtime \
     && dpkg-reconfigure -f noninteractive tzdata
@@ -31,6 +35,6 @@ COPY . /opt/rsem
 # Build and install RSEM
 RUN make && make install
 
-ENV PATH="/usr/local/bin:${PATH}"
+ENV PATH="/usr/local/bin:/usr/bin:${PATH}"
 
 CMD ["bash"]


### PR DESCRIPTION
## Summary
- Install Bowtie, Bowtie2, Samtools, and Tabix (providing bgzip/tabix) in Docker image
- Add /usr/bin to PATH so bioinformatics tools are accessible

## Testing
- `docker build -t rsem-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3bb1df40c8331ba9f81da86df869d