### PR TITLE
Install STAR 2.7.11b in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:22.04
 
+ARG STAR_VERSION=2.7.11b
+ENV STAR_VERSION=${STAR_VERSION}
+
 # Avoid interactive prompts and set a default timezone
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
@@ -22,9 +25,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bowtie2 \
     samtools \
     tabix \
+    unzip \
+    wget \
     && rm -rf /var/lib/apt/lists/* \
     && ln -fs /usr/share/zoneinfo/$TZ /etc/localtime \
     && dpkg-reconfigure -f noninteractive tzdata
+
+# Install STAR aligner version matching Snakemake wrapper v3.5.3/bio/star/align
+RUN wget -qO /tmp/star.zip "https://github.com/alexdobin/STAR/releases/download/${STAR_VERSION}/STAR_${STAR_VERSION}.zip" \
+    && unzip -q /tmp/star.zip -d /opt \
+    && install -m 0755 /opt/STAR_${STAR_VERSION}/Linux_x86_64_static/* /usr/local/bin/ \
+    && rm -rf /opt/STAR_${STAR_VERSION} /tmp/star.zip
 
 # Set working directory
 WORKDIR /opt/rsem


### PR DESCRIPTION
## Summary
- add a build argument for the STAR version used by the Snakemake wrapper
- download and install STAR 2.7.11b so its binaries are available on PATH inside the image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9859f260c8331b8c3d8b79a1fb02e