### PR TITLE
Optimize compiler flags for Xeon Platinum 8488C

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,11 @@ endif
 BOOST = .
 
 # Compilation variables
+# Use x86-64-v4/"native" tuning to leverage AVX-512/FMA capabilities reported by
+# the target Intel(R) Xeon(R) Platinum 8488C (see provided lscpu output).
 CXX = g++
-CXXFLAGS = -std=gnu++98 -Wall -I. -I$(BOOST) -I$(SAMTOOLS)/$(HTSLIB)
+CXXFLAGS = -std=gnu++98 -Wall -I. -I$(BOOST) -I$(SAMTOOLS)/$(HTSLIB) \
+           -march=x86-64-v4 -mtune=native
 CPPFLAGS =
 
 LDFLAGS =


### PR DESCRIPTION
## Summary
- document the target Intel Xeon Platinum 8488C architecture and adjust the default compiler flags to leverage its AVX-512 capable x86-64-v4 feature set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbdf5927b08331b1645e576bc3f60e