### PR TITLE
Install xxd dependency for STAR build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     liblzma-dev \
     libncurses5-dev \
     bowtie \
+    xxd \
     samtools \
     tabix \
     unzip \


### PR DESCRIPTION
## Summary
- add the xxd package to the build dependencies so STAR can be compiled successfully

## Testing
- `sudo docker build -t daylilyinformatics/rsem:1.3.3.5 .` *(fails: docker not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe18c484c8331b9eb68e1ad699ab2